### PR TITLE
Fix PHP 8.1 deprecation log

### DIFF
--- a/src/UnifiedArchive.php
+++ b/src/UnifiedArchive.php
@@ -789,6 +789,7 @@ class UnifiedArchive implements ArrayAccess, Iterator, Countable
      * @param mixed $offset
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->hasFile($offset);
@@ -799,6 +800,7 @@ class UnifiedArchive implements ArrayAccess, Iterator, Countable
      * @return mixed|string
      * @throws NonExistentArchiveFileException
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->getFileData($offset);
@@ -811,6 +813,7 @@ class UnifiedArchive implements ArrayAccess, Iterator, Countable
      * @throws ArchiveModificationException
      * @throws UnsupportedOperationException
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         return $this->addFileFromString($offset, $value);
@@ -822,11 +825,13 @@ class UnifiedArchive implements ArrayAccess, Iterator, Countable
      * @throws ArchiveModificationException
      * @throws UnsupportedOperationException
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         return $this->deleteFiles($offset);
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->files[$this->filesIterator];
@@ -835,26 +840,31 @@ class UnifiedArchive implements ArrayAccess, Iterator, Countable
     /**
      * @throws NonExistentArchiveFileException
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->getFileData($this->files[$this->filesIterator]);
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->filesIterator++;
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->filesIterator < $this->filesQuantity;
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->filesIterator = 0;
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->filesQuantity;


### PR DESCRIPTION
Fixes following errors seen while tests on PHP 8.1 RC environment.

Adding the `#[\ReturnTypeWillChange]` attribute is the only way to prevent these deprecations errors while maintaining compatibility with PHP < 8.0.


```
==> Error E_DEPRECATED in /var/glpi/vendor/wapmorgan/unified-archive/src/UnifiedArchive.php on line 792:
Return type of wapmorgan\UnifiedArchive\UnifiedArchive::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
==> Error E_DEPRECATED in /var/glpi/vendor/wapmorgan/unified-archive/src/UnifiedArchive.php on line 802:
Return type of wapmorgan\UnifiedArchive\UnifiedArchive::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
==> Error E_DEPRECATED in /var/glpi/vendor/wapmorgan/unified-archive/src/UnifiedArchive.php on line 814:
Return type of wapmorgan\UnifiedArchive\UnifiedArchive::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
==> Error E_DEPRECATED in /var/glpi/vendor/wapmorgan/unified-archive/src/UnifiedArchive.php on line 825:
Return type of wapmorgan\UnifiedArchive\UnifiedArchive::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
==> Error E_DEPRECATED in /var/glpi/vendor/wapmorgan/unified-archive/src/UnifiedArchive.php on line 838:
Return type of wapmorgan\UnifiedArchive\UnifiedArchive::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
==> Error E_DEPRECATED in /var/glpi/vendor/wapmorgan/unified-archive/src/UnifiedArchive.php on line 843:
Return type of wapmorgan\UnifiedArchive\UnifiedArchive::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
==> Error E_DEPRECATED in /var/glpi/vendor/wapmorgan/unified-archive/src/UnifiedArchive.php on line 830:
Return type of wapmorgan\UnifiedArchive\UnifiedArchive::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
==> Error E_DEPRECATED in /var/glpi/vendor/wapmorgan/unified-archive/src/UnifiedArchive.php on line 848:
Return type of wapmorgan\UnifiedArchive\UnifiedArchive::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
==> Error E_DEPRECATED in /var/glpi/vendor/wapmorgan/unified-archive/src/UnifiedArchive.php on line 853:
Return type of wapmorgan\UnifiedArchive\UnifiedArchive::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
==> Error E_DEPRECATED in /var/glpi/vendor/wapmorgan/unified-archive/src/UnifiedArchive.php on line 858:
Return type of wapmorgan\UnifiedArchive\UnifiedArchive::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```