### PR TITLE
static not self in OneFileDriver

### DIFF
--- a/src/Drivers/OneFile/OneFileDriver.php
+++ b/src/Drivers/OneFile/OneFileDriver.php
@@ -30,7 +30,7 @@ abstract class OneFileDriver extends BasicDriver
             throw new UnsupportedOperationException(self::FORMAT_SUFFIX.' archive does not support password!');
 
         $this->fileName = $archiveFileName;
-        $this->inArchiveFileName = basename($archiveFileName, '.'.self::FORMAT_SUFFIX);
+        $this->inArchiveFileName = basename($archiveFileName, '.'.static::FORMAT_SUFFIX);
     }
 
     /**


### PR DESCRIPTION
`self::FORMAT_SUFFIX` is null, `basename` will not end up extracting the extension from the filename. `static::FORMAT_SUFFIX` will provide the extension from the driver class.