### PR TITLE
Exclude dev files from dist package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/.github/         export-ignore
+/tests/           export-ignore
+/.gitattributes   export-ignore
+/.gitignore       export-ignore
+/.scrutinizer.yml export-ignore
+/.travis.yml      export-ignore
+/_config.yml      export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
For the time being, when fetching the dist package from composer, all repository files are included.
Using `export-ignore` git attribute would permit to make the dist package ligther (see https://php.watch/articles/composer-gitattributes#export-ignore).
