### PR TITLE
Alchemy\Zippy\Archive\Member::getLastModifiedDate() returns DateTime,…

### DIFF
--- a/src/Drivers/AlchemyZippy.php
+++ b/src/Drivers/AlchemyZippy.php
@@ -230,7 +230,7 @@ class AlchemyZippy extends BasicUtilityDriver
     public function getFileData($fileName)
     {
         $member = $this->getMember($fileName);
-        return new ArchiveEntry($member->getLocation(), $member->getSize(), $member->getSize(), strtotime($member->getLastModifiedDate()), true);
+        return new ArchiveEntry($member->getLocation(), $member->getSize(), $member->getSize(), $member->getLastModifiedDate()->getTimestamp(), true);
     }
 
     /**


### PR DESCRIPTION
… not string.

According to "git blame" this has always been the case, so the obvious fix is just use DateTime::getTimestamp() instead of strtotime().