### PR TITLE
BUG FIX: Write changes properly to LzwStreamWrapper::stream_truncate

### DIFF
--- a/src/LzwStreamWrapper.php
+++ b/src/LzwStreamWrapper.php
@@ -274,6 +274,7 @@ class LzwStreamWrapper
             if (file_exists($this->tmp2)) unlink($this->tmp2);
         } else {
             $this->data = null;
+            $this->dataSize = 0;
         }
     }
 
@@ -339,6 +340,7 @@ class LzwStreamWrapper
             $postfix = substr($this->data, ($this->pointer + $count));
             $this->data = $prefix.$data.$postfix;
             $this->pointer += $count;
+            $this->dataSize = strlen($this->data);
 
             return $count;
         }
@@ -396,6 +398,7 @@ class LzwStreamWrapper
         } elseif ($new_size < $actual_data_size) {
             if ($this->tmp === null) {
                 $this->data = substr($this->data, 0, $new_size);
+                $this->dataSize = strlen($this->data);
                 $this->writtenBytes = $new_size;
             } else {
                 $fp = fopen($this->tmp, 'w'.(strpos($this->mode, 'b') !== 0

--- a/src/LzwStreamWrapper.php
+++ b/src/LzwStreamWrapper.php
@@ -396,6 +396,7 @@ class LzwStreamWrapper
         } elseif ($new_size < $actual_data_size) {
             if ($this->tmp === null) {
                 $this->data = substr($this->data, 0, $new_size);
+                $this->writtenBytes = $new_size;
             } else {
                 $fp = fopen($this->tmp, 'w'.(strpos($this->mode, 'b') !== 0
                     ? 'b' : null));
@@ -403,7 +404,7 @@ class LzwStreamWrapper
                 fclose($fp);
             }
         }
-        
+
         return true;
     }
 

--- a/src/LzwStreamWrapper.php
+++ b/src/LzwStreamWrapper.php
@@ -403,6 +403,8 @@ class LzwStreamWrapper
                 fclose($fp);
             }
         }
+        
+        return true;
     }
 
     /**


### PR DESCRIPTION
There are 3 bugs in this PR

The first one is `LzwStreamWrapper::stream_truncate` needs to return boolean value in order to run properly

The second one, when running `LzwStreamWrapper::stream_truncate` with `$new_size` smaller than the original and no `tmp` file has been created, the truncation won't be written to file. This is because `$this->writtenBytes` was not updated when the data is truncated.

The third bug, when updating the data, the datasize is not updated. Thus, a call to `fstat` will return wrong value.