### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -37,10 +37,11 @@ jobs:
     # Docs: https://getcomposer.org/doc/articles/scripts.md
 
     - name: PHPUnit Tests
-      uses: php-actions/phpunit@v9
+      uses: php-actions/phpunit@v4
       env:
         XDEBUG_MODE: coverage
       with:
+        version: 9
         bootstrap: tests/bootstrap.php
         configuration: phpunit.xml.dist
         php_extensions: xdebug

--- a/=7.1
+++ b/=7.1
@@ -1,9 +1,0 @@
-[30;43mComposer could not detect the root package (wapmorgan/unified-archive) version, defaulting to '1.0.0'. See https://getcomposer.org/root-version[39;49m
-
-[33mIn BaseCommand.php line 402:[39m
-[37;41m                                                                 [39;49m
-[37;41m  Option php is missing a version constraint, use e.g. php:^1.0  [39;49m
-[37;41m                                                                 [39;49m
-
-[32mrequire [--dev] [--dry-run] [--prefer-source] [--prefer-dist] [--prefer-install PREFER-INSTALL] [--fixed] [--no-suggest] [--no-progress] [--no-update] [--no-install] [--no-audit] [--audit-format AUDIT-FORMAT] [--update-no-dev] [-w|--update-with-dependencies] [-W|--update-with-all-dependencies] [--with-dependencies] [--with-all-dependencies] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--prefer-stable] [--prefer-lowest] [-m|--minimal-changes] [--sort-packages] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--apcu-autoloader-prefix APCU-AUTOLOADER-PREFIX] [--] [<packages>...][39m
-

--- a/=7.1
+++ b/=7.1
@@ -1,0 +1,9 @@
+[30;43mComposer could not detect the root package (wapmorgan/unified-archive) version, defaulting to '1.0.0'. See https://getcomposer.org/root-version[39;49m
+
+[33mIn BaseCommand.php line 402:[39m
+[37;41m                                                                 [39;49m
+[37;41m  Option php is missing a version constraint, use e.g. php:^1.0  [39;49m
+[37;41m                                                                 [39;49m
+
+[32mrequire [--dev] [--dry-run] [--prefer-source] [--prefer-dist] [--prefer-install PREFER-INSTALL] [--fixed] [--no-suggest] [--no-progress] [--no-update] [--no-install] [--no-audit] [--audit-format AUDIT-FORMAT] [--update-no-dev] [-w|--update-with-dependencies] [-W|--update-with-all-dependencies] [--with-dependencies] [--with-all-dependencies] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--prefer-stable] [--prefer-lowest] [-m|--minimal-changes] [--sort-packages] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--apcu-autoloader-prefix APCU-AUTOLOADER-PREFIX] [--] [<packages>...][39m
+

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.5.0",
+		"php": ">=7.1",
 		"ext-fileinfo": "*"
 	},
 	"require-dev": {

--- a/src/Drivers/OneFile/OneFileDriver.php
+++ b/src/Drivers/OneFile/OneFileDriver.php
@@ -110,7 +110,7 @@ abstract class OneFileDriver extends BasicExtensionDriver
      * @return int
      * @throws ArchiveExtractionException
      */
-    public function extractFiles($outputFolder, array $files = null)
+    public function extractFiles($outputFolder, ?array $files = null)
     {
         return $this->extractArchive($outputFolder);
     }


### PR DESCRIPTION
Implicitly nullable parameter declarations are deprecated in PHP 8.4. The proposed change is safe and is not considered by PHP as a signature change, see https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

Unfortunately, this syntax is compatible only with PHP >= 7.1. I propose to raise the minimal PHP requirement to 7.1.