### PR TITLE
one file driver: add memory efficient chunk read/write unpacking of gzip files

### DIFF
--- a/src/Drivers/OneFile/OneFileDriver.php
+++ b/src/Drivers/OneFile/OneFileDriver.php
@@ -122,17 +122,21 @@ abstract class OneFileDriver extends BasicExtensionDriver
      */
     public function extractArchive($outputFolder)
     {
-        $data = $this->getFileContent($this->inArchiveFileName);
-        if ($data === false)
-            throw new ArchiveExtractionException('Could not extract archive');
+        if(method_exists($this, 'streamToFile')){
+            $this->streamToFile($outputFolder.$this->inArchiveFileName);
+        }else{
+            $data = $this->getFileContent($this->inArchiveFileName);
+            if ($data === false)
+                throw new ArchiveExtractionException('Could not extract archive');
 
-        $size = strlen($data);
-        $written = file_put_contents($outputFolder.$this->inArchiveFileName, $data);
+            $size = strlen($data);
+            $written = file_put_contents($outputFolder.$this->inArchiveFileName, $data);
 
-        if ($written === true) {
-            throw new ArchiveExtractionException('Could not extract file "'.$this->inArchiveFileName.'": could not write data');
-        } else if ($written < $size) {
-            throw new ArchiveExtractionException('Could not archive file "'.$this->inArchiveFileName.'": written '.$written.' of '.$size);
+            if ($written === true) {
+                throw new ArchiveExtractionException('Could not extract file "'.$this->inArchiveFileName.'": could not write data');
+            } else if ($written < $size) {
+                throw new ArchiveExtractionException('Could not archive file "'.$this->inArchiveFileName.'": written '.$written.' of '.$size);
+            }
         }
         return 1;
     }


### PR DESCRIPTION
Previously the whole unpacked file was loaded into memory.
This implementation allows to unpack gz files in a streamed way. 